### PR TITLE
Add Go tests and sample binaries

### DIFF
--- a/watsontcp-go/client_server_test.go
+++ b/watsontcp-go/client_server_test.go
@@ -1,0 +1,119 @@
+package watsontcpgo_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/yourname/watsontcp-go/client"
+	"github.com/yourname/watsontcp-go/message"
+	"github.com/yourname/watsontcp-go/server"
+)
+
+func newTLSConfig() (*tls.Config, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	tmpl := x509.Certificate{SerialNumber: big.NewInt(1), NotBefore: time.Now(), NotAfter: time.Now().Add(time.Hour)}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, err
+	}
+	cert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	key := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	tlsCert, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{Certificates: []tls.Certificate{tlsCert}, InsecureSkipVerify: true}, nil
+}
+
+func startServer(t *testing.T, addr string, tlsConf *tls.Config, cb server.Callbacks) *server.Server {
+	srv := server.New(addr, tlsConf, cb, nil)
+	if err := srv.Start(); err != nil {
+		t.Fatalf("server start: %v", err)
+	}
+	return srv
+}
+
+func TestClientServerCommunication(t *testing.T) {
+	done := make(chan struct{})
+	cb := server.Callbacks{
+		OnMessage: func(id string, msg *message.Message, data []byte) { close(done) },
+	}
+	srv := startServer(t, "127.0.0.1:30000", nil, cb)
+	defer srv.Stop()
+
+	cli := client.New("127.0.0.1:30000", nil, client.Callbacks{}, nil)
+	if err := cli.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer cli.Disconnect()
+
+	if err := cli.Send(&message.Message{}, []byte("hi")); err != nil {
+		time.Sleep(200 * time.Millisecond)
+		t.Fatalf("send: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("message not received")
+	}
+}
+
+func TestTLSConnection(t *testing.T) {
+	tlsConf, err := newTLSConfig()
+	if err != nil {
+		t.Fatalf("tls: %v", err)
+	}
+	srv := startServer(t, "127.0.0.1:30001", tlsConf, server.Callbacks{})
+	defer srv.Stop()
+
+	cli := client.New("127.0.0.1:30001", &tls.Config{InsecureSkipVerify: true}, client.Callbacks{}, nil)
+	if err := cli.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	cli.Disconnect()
+}
+
+func TestSendSync(t *testing.T) {
+	var conn net.Conn
+	cb := server.Callbacks{
+		OnConnect: func(id string, c net.Conn) { conn = c },
+		OnMessage: func(id string, msg *message.Message, data []byte) {
+			if msg.SyncRequest {
+				resp := &message.Message{SyncResponse: true, ConversationGUID: msg.ConversationGUID, ContentLength: int64(len("pong"))}
+				hdr, _ := message.BuildHeader(resp)
+				conn.Write(hdr)
+				conn.Write([]byte("pong"))
+			}
+		},
+	}
+	srv := startServer(t, "127.0.0.1:30002", nil, cb)
+	defer srv.Stop()
+
+	cli := client.New("127.0.0.1:30002", nil, client.Callbacks{}, nil)
+	if err := cli.Connect(); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer cli.Disconnect()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	resp, data, err := cli.SendSync(ctx, &message.Message{}, []byte("ping"))
+	if err != nil {
+		t.Fatalf("SendSync: %v", err)
+	}
+	if string(data) != "pong" || !resp.SyncResponse {
+		t.Fatalf("bad response")
+	}
+}

--- a/watsontcp-go/examples/Test.Client/main.go
+++ b/watsontcp-go/examples/Test.Client/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/yourname/watsontcp-go/client"
+	"github.com/yourname/watsontcp-go/message"
+)
+
+func main() {
+	cb := client.Callbacks{}
+	cb.OnMessage = func(msg *message.Message, data []byte) {
+		fmt.Printf("server: %s\n", string(data))
+	}
+	c := client.New("127.0.0.1:9000", nil, cb, nil)
+	if err := c.Connect(); err != nil {
+		panic(err)
+	}
+	defer c.Disconnect()
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("msg> ")
+		if !scanner.Scan() {
+			break
+		}
+		txt := scanner.Text()
+		if txt == "" {
+			continue
+		}
+		c.Send(&message.Message{}, []byte(txt))
+	}
+}

--- a/watsontcp-go/examples/Test.Server/main.go
+++ b/watsontcp-go/examples/Test.Server/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"github.com/yourname/watsontcp-go/message"
+	"github.com/yourname/watsontcp-go/server"
+	"log"
+)
+
+func main() {
+	cb := server.Callbacks{}
+	cb.OnMessage = func(id string, msg *message.Message, data []byte) {
+		fmt.Printf("%s: %s\n", id, string(data))
+	}
+	srv := server.New("127.0.0.1:9000", nil, cb, nil)
+	if err := srv.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer srv.Stop()
+	select {}
+}

--- a/watsontcp-go/examples/Test.SyncMessages/main.go
+++ b/watsontcp-go/examples/Test.SyncMessages/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"github.com/yourname/watsontcp-go/client"
+	"github.com/yourname/watsontcp-go/message"
+	"github.com/yourname/watsontcp-go/server"
+)
+
+func main() {
+	var conn net.Conn
+	cb := server.Callbacks{
+		OnConnect: func(id string, c net.Conn) { conn = c },
+		OnMessage: func(id string, msg *message.Message, data []byte) {
+			if msg.SyncRequest {
+				resp := &message.Message{SyncResponse: true, ConversationGUID: msg.ConversationGUID}
+				hdr, _ := message.BuildHeader(resp)
+				conn.Write(hdr)
+				resp.ContentLength = int64(len("world"))
+				conn.Write([]byte("world"))
+			}
+		},
+	}
+	srv := server.New("127.0.0.1:9001", nil, cb, nil)
+	if err := srv.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer srv.Stop()
+
+	cl := client.New("127.0.0.1:9001", nil, client.Callbacks{}, nil)
+	if err := cl.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer cl.Disconnect()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	resp, data, err := cl.SendSync(ctx, &message.Message{}, []byte("hello"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("response: %s (%v)\n", string(data), resp.SyncResponse)
+}

--- a/watsontcp-go/message/header_test.go
+++ b/watsontcp-go/message/header_test.go
@@ -1,0 +1,32 @@
+package message
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBuildParseHeader(t *testing.T) {
+	msg := &Message{Status: StatusNormal, ContentLength: 5}
+	hdr, err := BuildHeader(msg)
+	if err != nil {
+		t.Fatalf("build header: %v", err)
+	}
+	if !bytes.HasSuffix(hdr, []byte{'\r', '\n', '\r', '\n'}) {
+		t.Fatalf("header missing delimiter")
+	}
+	parsed, err := ParseHeader(bytes.NewReader(hdr))
+	if err != nil {
+		t.Fatalf("parse header: %v", err)
+	}
+	if parsed.Status != msg.Status || parsed.ContentLength != msg.ContentLength {
+		t.Fatalf("parsed message mismatch")
+	}
+}
+
+func TestParseHeaderPeerDisconnect(t *testing.T) {
+	data := []byte("\x00\x00\x00\x00")
+	_, err := ParseHeader(bytes.NewReader(data))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- create message framing tests
- add integration tests for server/client and TLS
- add simple examples for server, client, and sync messages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e142e7200832ebc296514fab5f949