### PR TITLE
Add Go usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Special thanks to the following people for their support and contributions to th
 @YorVeX @tovich37 @sancheolz @lunedis @ShayanFiroozi
 
 If you'd like to contribute, please jump right into the source code and create a pull request, or, file an issue with your enhancement request. 
+## Go Implementation
+A reference Go version is available in `watsontcp-go`. See [watsontcp-go/README.md](watsontcp-go/README.md) for usage.
+
 
 ## New in v6.0.x
 

--- a/watsontcp-go/README.md
+++ b/watsontcp-go/README.md
@@ -1,0 +1,83 @@
+# WatsonTcp for Go
+
+This directory contains an experimental Go implementation of WatsonTcp. The API mirrors the C# library where possible and provides simple client and server types.
+
+## Installing
+
+```
+go get github.com/yourname/watsontcp-go
+```
+
+Import the desired packages:
+
+```go
+import (
+    "github.com/yourname/watsontcp-go/client"
+    "github.com/yourname/watsontcp-go/server"
+)
+```
+
+## Basic Usage
+
+### Server
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/yourname/watsontcp-go/message"
+    "github.com/yourname/watsontcp-go/server"
+    "log"
+)
+
+func main() {
+    cb := server.Callbacks{}
+    cb.OnMessage = func(id string, msg *message.Message, data []byte) {
+        fmt.Printf("%s: %s\n", id, string(data))
+    }
+
+    srv := server.New("127.0.0.1:9000", nil, cb, nil)
+    if err := srv.Start(); err != nil {
+        log.Fatal(err)
+    }
+    defer srv.Stop()
+    select {}
+}
+```
+
+### Client
+```go
+package main
+
+import (
+    "github.com/yourname/watsontcp-go/client"
+    "github.com/yourname/watsontcp-go/message"
+    "log"
+)
+
+func main() {
+    cb := client.Callbacks{}
+    cb.OnMessage = func(msg *message.Message, data []byte) {
+        log.Printf("server: %s", string(data))
+    }
+
+    c := client.New("127.0.0.1:9000", nil, cb, nil)
+    if err := c.Connect(); err != nil {
+        log.Fatal(err)
+    }
+    defer c.Disconnect()
+
+    c.Send(&message.Message{}, []byte("hello"))
+}
+```
+
+## Differences from the C# Version
+
+The Go implementation provides the same framing protocol and message structure as the C# library but is a smaller code base with fewer features:
+
+- Only a subset of configuration options are implemented (e.g. keepalive and authentication options are present but not fully enforced).
+- Event callbacks are simple function pointers rather than events/delegates.
+- Client and server statistics are limited to byte and message counts.
+
+Because the wire protocol is shared, a Go client can communicate with a C# server and vice versa if the framing and message fields match. Features that are not implemented in one language (such as preshared-key authentication) must be handled manually or disabled on the peer.
+


### PR DESCRIPTION
## Summary
- document Go implementation usage under `watsontcp-go`
- note Go version in the main README

## Testing
- `go test ./...` *(fails: message not received)*
- `dotnet build src/WatsonTcp/WatsonTcp.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e173fbaf4832e9aa60d895d4dac02