### PR TITLE
Add server connection filters

### DIFF
--- a/watsontcp-go/server/options.go
+++ b/watsontcp-go/server/options.go
@@ -17,6 +17,19 @@ type Options struct {
 
 	// PresharedKey expected from clients.
 	PresharedKey string
+
+	// MaxConnections specifies the maximum number of concurrent
+	// connections the server will accept. Zero means unlimited.
+	MaxConnections int
+
+	// PermittedIPs is an optional list of IP addresses or CIDR ranges
+	// that are allowed to connect. If empty, all clients are permitted
+	// unless present in BlockedIPs.
+	PermittedIPs []string
+
+	// BlockedIPs specifies IP addresses or CIDR ranges that should be
+	// rejected when a client attempts to connect.
+	BlockedIPs []string
 }
 
 // KeepAlive mirrors WatsonTcp keepalive settings.
@@ -39,5 +52,8 @@ func DefaultOptions() Options {
 			Time:       5 * time.Second,
 			RetryCount: 5,
 		},
+		MaxConnections: 0,
+		PermittedIPs:   nil,
+		BlockedIPs:     nil,
 	}
 }


### PR DESCRIPTION
## Summary
- add connection filtering options to server: `MaxConnections`, `PermittedIPs`, and `BlockedIPs`
- enforce limits before accepting a connection
- test connection blocking and limiting behaviour

## Testing
- `go vet ./...`
- `go test ./...` *(fails: message not received)*

------
https://chatgpt.com/codex/tasks/task_e_686e313091b8832eba5a87ef809bce7f