### PR TITLE
Add streaming support and examples

### DIFF
--- a/watsontcp-go/examples/Test.FileTransfer/main.go
+++ b/watsontcp-go/examples/Test.FileTransfer/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"io"
+	"log"
+	"net"
+	"os"
+
+	"github.com/yourname/watsontcp-go/client"
+	"github.com/yourname/watsontcp-go/message"
+	"github.com/yourname/watsontcp-go/server"
+)
+
+func main() {
+	sample := []byte("sample data for streaming")
+	os.WriteFile("sample.txt", sample, 0644)
+
+	var srv *server.Server
+
+	srvCb := server.Callbacks{
+		OnConnect: func(id string, c net.Conn) {
+			f, err := os.Open("sample.txt")
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			fi, _ := f.Stat()
+			defer f.Close()
+			srv.SendStream(id, &message.Message{}, f, fi.Size())
+		},
+		OnStream: func(id string, msg *message.Message, r io.Reader) {
+			out, _ := os.Create("from_client.txt")
+			io.Copy(out, r)
+			out.Close()
+			log.Println("server received file from client")
+		},
+	}
+
+	srv = server.New("127.0.0.1:9100", nil, srvCb, nil)
+	if err := srv.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer srv.Stop()
+
+	cliCb := client.Callbacks{
+		OnStream: func(msg *message.Message, r io.Reader) {
+			out, _ := os.Create("from_server.txt")
+			io.Copy(out, r)
+			out.Close()
+			log.Println("client received file from server")
+		},
+	}
+
+	cli := client.New("127.0.0.1:9100", nil, cliCb, nil)
+	if err := cli.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer cli.Disconnect()
+
+	f, _ := os.Open("sample.txt")
+	fi, _ := f.Stat()
+	cli.SendStream(&message.Message{}, f, fi.Size())
+	f.Close()
+
+	select {}
+}

--- a/watsontcp-go/examples/Test.ServerStream/main.go
+++ b/watsontcp-go/examples/Test.ServerStream/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"log"
+	"net"
+	"os"
+
+	"github.com/yourname/watsontcp-go/message"
+	"github.com/yourname/watsontcp-go/server"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("usage: %s <file>", os.Args[0])
+	}
+	file := os.Args[1]
+
+	var srv *server.Server
+
+	cb := server.Callbacks{
+		OnConnect: func(id string, c net.Conn) {
+			f, err := os.Open(file)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			fi, _ := f.Stat()
+			defer f.Close()
+			srv.SendStream(id, &message.Message{}, f, fi.Size())
+		},
+	}
+
+	srv = server.New("127.0.0.1:9200", nil, cb, nil)
+	if err := srv.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer srv.Stop()
+	log.Printf("serving %s on 127.0.0.1:9200", file)
+	select {}
+}


### PR DESCRIPTION
## Summary
- add OnStream callbacks and SendStream methods for client and server
- forward data in read loops without allocating full payloads when using streams
- demonstrate file transfer and server-driven streaming examples

## Testing
- `go build ./...`
- `go test ./...` *(fails: TestSendSync, TestPresharedKeySuccess)*

------
https://chatgpt.com/codex/tasks/task_e_686e33325248832ea894971018c8e7b5