### PR TITLE
Add message size averages to Go stats

### DIFF
--- a/watsontcp-go/stats/stats.go
+++ b/watsontcp-go/stats/stats.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"fmt"
 	"sync/atomic"
 	"time"
 )
@@ -37,6 +38,24 @@ func (s *Statistics) SentBytes() int64 { return atomic.LoadInt64(&s.sentBytes) }
 // SentMessages returns the total messages sent.
 func (s *Statistics) SentMessages() int64 { return atomic.LoadInt64(&s.sentMsgs) }
 
+// ReceivedMessageSizeAverage returns the average size in bytes of received messages.
+func (s *Statistics) ReceivedMessageSizeAverage() int64 {
+	msgs := s.ReceivedMessages()
+	if msgs == 0 {
+		return 0
+	}
+	return s.ReceivedBytes() / msgs
+}
+
+// SentMessageSizeAverage returns the average size in bytes of sent messages.
+func (s *Statistics) SentMessageSizeAverage() int64 {
+	msgs := s.SentMessages()
+	if msgs == 0 {
+		return 0
+	}
+	return s.SentBytes() / msgs
+}
+
 // AddReceivedBytes increments the received byte counter.
 func (s *Statistics) AddReceivedBytes(n int64) { atomic.AddInt64(&s.receivedBytes, n) }
 
@@ -55,4 +74,19 @@ func (s *Statistics) Reset() {
 	atomic.StoreInt64(&s.receivedMsgs, 0)
 	atomic.StoreInt64(&s.sentBytes, 0)
 	atomic.StoreInt64(&s.sentMsgs, 0)
+}
+
+// String returns a formatted human-readable representation of the statistics.
+func (s *Statistics) String() string {
+	return fmt.Sprintf("--- Statistics ---%s    Started     : %s%s    Uptime      : %s%s    Received    : %s       Bytes    : %d%s       Messages : %d%s       Average  : %d bytes%s    Sent        : %s       Bytes    : %d%s       Messages : %d%s       Average  : %d bytes%s",
+		"\n", s.startTime.Format(time.RFC3339), "\n",
+		s.UpTime().String(), "\n",
+		"\n",
+		s.ReceivedBytes(), "\n",
+		s.ReceivedMessages(), "\n",
+		s.ReceivedMessageSizeAverage(), "\n",
+		"\n",
+		s.SentBytes(), "\n",
+		s.SentMessages(), "\n",
+		s.SentMessageSizeAverage(), "\n")
 }

--- a/watsontcp-go/stats/stats_test.go
+++ b/watsontcp-go/stats/stats_test.go
@@ -1,0 +1,39 @@
+package stats
+
+import "testing"
+
+func TestMessageSizeAverages(t *testing.T) {
+	s := New()
+	s.AddReceivedBytes(50)
+	s.IncrementReceivedMessages()
+	s.AddReceivedBytes(100)
+	s.IncrementReceivedMessages()
+	s.AddSentBytes(30)
+	s.IncrementSentMessages()
+	s.AddSentBytes(70)
+	s.IncrementSentMessages()
+
+	if s.ReceivedMessageSizeAverage() != 75 {
+		t.Fatalf("expected avg 75 got %d", s.ReceivedMessageSizeAverage())
+	}
+	if s.SentMessageSizeAverage() != 50 {
+		t.Fatalf("expected avg 50 got %d", s.SentMessageSizeAverage())
+	}
+
+	start := s.StartTime()
+	s.Reset()
+	if s.ReceivedBytes() != 0 || s.SentBytes() != 0 || s.ReceivedMessages() != 0 || s.SentMessages() != 0 {
+		t.Fatalf("reset did not clear counters")
+	}
+	if !s.StartTime().Equal(start) {
+		t.Fatalf("reset should not change start time")
+	}
+}
+
+func TestStringOutput(t *testing.T) {
+	s := New()
+	out := s.String()
+	if len(out) == 0 || out[0] != '-' {
+		t.Fatalf("unexpected string output: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- extend `stats.Statistics` with `ReceivedMessageSizeAverage` and `SentMessageSizeAverage`
- implement `String()` helper returning formatted statistics
- add tests covering the new metrics and `Reset`

## Testing
- `go vet ./...`
- `go test ./stats -run Test`
- `go test ./...` *(fails: message not received)*

------
https://chatgpt.com/codex/tasks/task_e_686e38c04850832ea4b8864550d3bc8b