### PR TITLE
Add Go examples for metadata, parallel sends and reconnect

### DIFF
--- a/watsontcp-go/README.md
+++ b/watsontcp-go/README.md
@@ -94,3 +94,13 @@ The Go implementation provides the same framing protocol and message structure a
 
 Because the wire protocol is shared, a Go client can communicate with a C# server and vice versa if the framing and message fields match. Features that are not implemented in one language (such as preshared-key authentication) must be handled manually or disabled on the peer.
 
+
+## Examples
+
+The `examples/` directory contains small programs demonstrating library features. Notable examples include:
+
+- `Test.Metadata` – sending messages with metadata maps.
+- `Test.Parallel` – multiple clients sending in parallel to a single server.
+- `Test.Reconnect` – reconnect logic that repeatedly connects and disconnects.
+
+Run `go build ./examples/<ExampleName>` to compile an example.

--- a/watsontcp-go/examples/Test.Metadata/main.go
+++ b/watsontcp-go/examples/Test.Metadata/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/yourname/watsontcp-go/client"
+	"github.com/yourname/watsontcp-go/message"
+	"github.com/yourname/watsontcp-go/server"
+)
+
+func main() {
+	srvCb := server.Callbacks{
+		OnMessage: func(id string, msg *message.Message, data []byte) {
+			fmt.Printf("server received '%s' with %d metadata entries\n", string(data), len(msg.Metadata))
+		},
+	}
+	srv := server.New("127.0.0.1:9102", nil, srvCb, nil)
+	if err := srv.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer srv.Stop()
+
+	time.Sleep(time.Second)
+
+	cli := client.New("127.0.0.1:9102", nil, client.Callbacks{}, nil)
+	if err := cli.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer cli.Disconnect()
+
+	md := map[string]any{
+		"foo":    "bar",
+		"number": 42,
+	}
+	msg := &message.Message{Metadata: md}
+	if err := cli.Send(msg, []byte("hello")); err != nil {
+		log.Fatal(err)
+	}
+
+	time.Sleep(time.Second)
+}

--- a/watsontcp-go/examples/Test.Parallel/main.go
+++ b/watsontcp-go/examples/Test.Parallel/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"crypto/md5"
+	"fmt"
+	"log"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/yourname/watsontcp-go/client"
+	"github.com/yourname/watsontcp-go/message"
+	"github.com/yourname/watsontcp-go/server"
+)
+
+const (
+	serverAddr    = "127.0.0.1:9101"
+	clientThreads = 4
+	numIterations = 1000
+)
+
+func main() {
+	data := make([]byte, 262144)
+	fmt.Printf("data md5: %x\n", md5.Sum(data))
+
+	srvCb := server.Callbacks{
+		OnMessage: func(id string, msg *message.Message, d []byte) {
+			fmt.Printf("[server] %s %x (%d bytes)\n", id, md5.Sum(d), len(d))
+		},
+	}
+	srv := server.New(serverAddr, nil, srvCb, nil)
+	if err := srv.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer srv.Stop()
+
+	time.Sleep(time.Second)
+
+	var wg sync.WaitGroup
+	for i := 0; i < clientThreads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cli := client.New(serverAddr, nil, client.Callbacks{}, nil)
+			if err := cli.Connect(); err != nil {
+				log.Println("connect:", err)
+				return
+			}
+			defer cli.Disconnect()
+			for j := 0; j < numIterations; j++ {
+				time.Sleep(time.Duration(rand.Intn(25)) * time.Millisecond)
+				cli.Send(&message.Message{}, data)
+			}
+			fmt.Println("[client] finished")
+		}()
+	}
+
+	wg.Wait()
+}

--- a/watsontcp-go/examples/Test.Reconnect/main.go
+++ b/watsontcp-go/examples/Test.Reconnect/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/yourname/watsontcp-go/client"
+	"github.com/yourname/watsontcp-go/message"
+)
+
+const addr = "127.0.0.1:9000"
+
+func main() {
+	for {
+		cli := client.New(addr, nil, client.Callbacks{
+			OnMessage: func(msg *message.Message, data []byte) {
+				fmt.Printf("server: %s\n", string(data))
+			},
+		}, nil)
+
+		if err := cli.Connect(); err != nil {
+			log.Println("connect:", err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		fmt.Printf("%s connected\n", time.Now().UTC().Format(time.RFC3339))
+		time.Sleep(time.Duration(rand.Intn(2000)+1000) * time.Millisecond)
+		cli.Disconnect()
+	}
+}


### PR DESCRIPTION
## Summary
- create Go examples for metadata, parallel sending and reconnect logic
- update Go README to reference new examples

## Testing
- `go build ./watsontcp-go/examples/Test.Metadata`
- `go build ./watsontcp-go/examples/Test.Parallel`
- `go build ./watsontcp-go/examples/Test.Reconnect`
- `go test ./watsontcp-go/...` *(fails: context deadline exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_686e3c87e09c832e897dec025bda2dd0