### PR TITLE
Fix sync responses and add connection handshake

### DIFF
--- a/watsontcp-go/server/server.go
+++ b/watsontcp-go/server/server.go
@@ -129,6 +129,9 @@ func (s *Server) acceptLoop() {
 		s.mu.Lock()
 		if s.maxConnections > 0 && len(s.conns) >= s.maxConnections {
 			s.mu.Unlock()
+			if tcp, ok := conn.(*net.TCPConn); ok {
+				tcp.SetLinger(0)
+			}
 			conn.Close()
 			continue
 		}
@@ -186,6 +189,13 @@ func (s *Server) handleConn(id string) {
 		}
 		resp := &message.Message{Status: message.StatusAuthSuccess}
 		if hdr, err := message.BuildHeader(resp); err == nil {
+			c.conn.Write(hdr)
+		}
+		if hdr, err := message.BuildHeader(&message.Message{Status: message.StatusRegisterClient}); err == nil {
+			c.conn.Write(hdr)
+		}
+	} else {
+		if hdr, err := message.BuildHeader(&message.Message{Status: message.StatusRegisterClient}); err == nil {
 			c.conn.Write(hdr)
 		}
 	}


### PR DESCRIPTION
## Summary
- avoid extra buffering when parsing headers
- send server registration message on connect and verify it in client
- close refused connections with RST to enforce MaxConnections

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e3e72d67c832ea78075573a6b1011